### PR TITLE
Remove try/catch

### DIFF
--- a/vulnerabilities/xxe/index.js
+++ b/vulnerabilities/xxe/index.js
@@ -32,12 +32,9 @@ api.post(['/safe', '/unsafe'], (req, res) => {
 		};
 	}
 
-	try {
-		const parsedXML = libxmljs.parseXmlString(ATTACK_XML, options);
-		res.send(parsedXML.toString());
-	} catch(error) {
-		res.status('400').send('Unable to process XML string');
-	}
+
+	const parsedXML = libxmljs.parseXmlString(ATTACK_XML, options);
+	res.send(parsedXML.toString());
 });
 
 module.exports = api;


### PR DESCRIPTION
The XML being parsed is static and known to be parsable, so the try/catch is not necessary. And the 400 error makes no sense either since the user isn't supplying the XML.

We also want to have the agent automatically handle the security exception when XXE is in blocking mode and the method is called with unsafe options.